### PR TITLE
[Fix] return zero instead of empty result on CR10 and CR11

### DIFF
--- a/tugraph/src/main/java/org/ldbcouncil/finbench/impls/tugraph/TuGraphTransactionDb.java
+++ b/tugraph/src/main/java/org/ldbcouncil/finbench/impls/tugraph/TuGraphTransactionDb.java
@@ -406,7 +406,7 @@ public class TuGraphTransactionDb extends Db {
                 ResultReporter resultReporter) throws DbException {
             try {
                 TuGraphDbRpcClient client = dbConnectionState.popClient();
-                String cypher = "MATCH (p1:Person {id:%d})-[edge1:invest]->(m1:Company) WHERE edge1.timestamp > %d AND edge1.timestamp < %d WITH collect(distinct id(m1)) as m1_vids MATCH (p2:Person {id:%d})-[edge2:invest]->(m2:Company) WHERE edge2.timestamp > %d AND edge2.timestamp < %d WITH collect(distinct id(m2)) as m2_vids, m1_vids CALL algo.jaccard(m1_vids, m2_vids) YIELD similarity RETURN round(similarity*1000)/1000 AS similarity;";
+                String cypher = "OPTIONAL MATCH (p1:Person {id:%d})-[edge1:invest]->(m1:Company) WHERE edge1.timestamp > %d AND edge1.timestamp < %d WITH collect(distinct id(m1)) as m1_vids OPTIONAL MATCH (p2:Person {id:%d})-[edge2:invest]->(m2:Company) WHERE edge2.timestamp > %d AND edge2.timestamp < %d WITH collect(distinct id(m2)) as m2_vids, m1_vids CALL algo.jaccard(m1_vids, m2_vids) YIELD similarity RETURN CASE WHEN similarity = null THEN 0 ELSE round(similarity*1000)/1000 END AS similarity;";
                 long startTime = cr10.getStartTime().getTime();
                 long endTime = cr10.getEndTime().getTime();
                 cypher = String.format(
@@ -437,7 +437,7 @@ public class TuGraphTransactionDb extends Db {
                 ResultReporter resultReporter) throws DbException {
             try {
                 TuGraphDbRpcClient client = dbConnectionState.popClient();
-                String cypher = "MATCH (p1:Person {id:%d})-[edge:guarantee*1..5]->(pN:Person) -[:apply]->(loan:Loan) WHERE minInList(getMemberProp(edge, 'timestamp')) > %d AND maxInList(getMemberProp(edge, 'timestamp')) < %d WITH DISTINCT loan WITH sum(loan.loanAmount) as sumLoanAmount, count(distinct loan) as numLoans RETURN round(sumLoanAmount * 1000) / 1000 as sumLoanAmount, numLoans;";
+                String cypher = "OPTIONAL MATCH (p1:Person {id:%d})-[edge:guarantee*1..5]->(pN:Person) -[:apply]->(loan:Loan) WHERE minInList(getMemberProp(edge, 'timestamp')) > %d AND maxInList(getMemberProp(edge, 'timestamp')) < %d WITH DISTINCT loan WITH sum(loan.loanAmount) as sumLoanAmount, count(distinct loan) as numLoans RETURN round(sumLoanAmount * 1000) / 1000 as sumLoanAmount, numLoans;";
                 long startTime = cr11.getStartTime().getTime();
                 long endTime = cr11.getEndTime().getTime();
                 cypher = String.format(


### PR DESCRIPTION
CR10 and CR11 now return 0 instead of empty when no edges or nodes are matched.